### PR TITLE
Refactor User model base and add migration

### DIFF
--- a/backend/alembic/versions/67f68ba45b75_create_users_table.py
+++ b/backend/alembic/versions/67f68ba45b75_create_users_table.py
@@ -1,0 +1,38 @@
+"""create users table
+
+Revision ID: 67f68ba45b75
+Revises: 
+Create Date: 2024-07-02 00:00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '67f68ba45b75'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('full_name', sa.String(), nullable=True),
+        sa.Column('role', sa.Enum('client', 'admin', name='userrole'), nullable=False, server_default='client'),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_users_email'), 'users', ['email'], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_users_email'), table_name='users')
+    op.drop_table('users')
+    op.execute('DROP TYPE userrole')

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,8 +1,6 @@
 from sqlalchemy import Column, Integer, String, Enum
-from sqlalchemy.ext.declarative import declarative_base
+from app.core.database import Base
 import enum
-
-Base = declarative_base()
 
 class UserRole(str, enum.Enum):
     client = "client"


### PR DESCRIPTION
## Summary
- refactor `User` model to import shared `Base`
- add Alembic migration creating `users` table

## Testing
- `PYTHONPATH=.venv/lib/python3.9/site-packages:. python3 -m alembic --version` *(fails: ModuleNotFoundError: No module named 'pydantic_core._pydantic_core')*

------
https://chatgpt.com/codex/tasks/task_e_686505d23fa4832480e460da12f5f673